### PR TITLE
Use torch.equal for tensor equality comparisons

### DIFF
--- a/ControlFlowUtils.py
+++ b/ControlFlowUtils.py
@@ -787,9 +787,15 @@ HOVER OVER THE INPUTS AND OUTPUTS FOR MORE INFO.
 				case "B in A":
 					ret = (B in A)
 				case "A == B":
-					ret = (A == B)
+					if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
+						ret = torch.equal(A, B)
+					else:
+						ret = (A == B)
 				case "A != B":
-					ret = (A != B)
+					if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
+						ret = not torch.equal(A, B)
+					else:
+						ret = (A != B)
 				case "A > B":
 					ret = (A > B)
 				case "A >= B":


### PR DESCRIPTION
`torch.equal` handles equality better than `torch.Tensor.__eq__` for this purpose. In particular, it won't raise exception when tensors have different rank or shape.